### PR TITLE
findAndSetSegment02() cleanup and bug fix

### DIFF
--- a/src/ROM.cs
+++ b/src/ROM.cs
@@ -672,88 +672,49 @@ namespace Quad64
             AssemblyReader ar = new AssemblyReader();
             List<AssemblyReader.JAL_CALL> func_calls;
             SegBank seg = new SegBank();
+            uint seg02_init;
+            uint RAMtoROM;
             switch (region)
             {
                 default:
                 case ROM_Region.NORTH_AMERICA:
-                    func_calls = ar.findJALsInFunction(Globals.seg02_init_NA, Globals.RAMtoROM_NA);
-                    for (int i = 0; i < func_calls.Count; i++)
-                    {
-                        if (func_calls[i].a0 == 0x2)
-                        {
-                            Globals.seg02_location = new[] { func_calls[i].a1, func_calls[i].a2 };
-                            if (readWordUnsigned(func_calls[i].a1) == 0x4D494F30)
-                            {
-                                seg.IsMIO0 = true;
-                                seg02_isFakeMIO0 = testIfMIO0IsFake(
-                                    func_calls[i].a1,
-                                    readWord(func_calls[i].a1 + 0x8),
-                                    readWord(func_calls[i].a1 + 0xC)
-                                 );
-                                seg.SegStart = func_calls[i].a1;
-                                seg02_uncompressedOffset = readWordUnsigned(func_calls[i].a1 + 0xC);
-                            }
-                        }
-                    }
+                    seg02_init = Globals.seg02_init_NA;
+                    RAMtoROM = Globals.RAMtoROM_NA;
                     break;
                 case ROM_Region.EUROPE:
-                    func_calls = ar.findJALsInFunction(Globals.seg02_init_EU, Globals.RAMtoROM_EU);
-                    for (int i = 0; i < func_calls.Count; i++)
-                        if (func_calls[i].a0 == 0x2)
-                        {
-                            Globals.seg02_location = new[] { func_calls[i].a1, func_calls[i].a2 };
-                            if (readWordUnsigned(func_calls[i].a1) == 0x4D494F30)
-                            {
-                                seg.IsMIO0 = true;
-                                seg02_isFakeMIO0 = testIfMIO0IsFake(
-                                    func_calls[i].a1,
-                                    readWord(func_calls[i].a1 + 0x8),
-                                    readWord(func_calls[i].a1 + 0xC)
-                                 );
-                                seg.SegStart = func_calls[i].a1;
-                                seg02_uncompressedOffset = readWordUnsigned(func_calls[i].a1 + 0xC);
-                            }
-                        }
+                    seg02_init = Globals.seg02_init_EU;
+                    RAMtoROM = Globals.RAMtoROM_EU;
                     break;
                 case ROM_Region.JAPAN:
-                    func_calls = ar.findJALsInFunction(Globals.seg02_init_JP, Globals.RAMtoROM_JP);
-                    for (int i = 0; i < func_calls.Count; i++)
-                        if (func_calls[i].a0 == 0x2)
-                        {
-                            Globals.seg02_location = new[] { func_calls[i].a1, func_calls[i].a2 };
-                            if (readWordUnsigned(func_calls[i].a1) == 0x4D494F30)
-                            {
-                                seg.IsMIO0 = true;
-                                seg02_isFakeMIO0 = testIfMIO0IsFake(
-                                    func_calls[i].a1,
-                                    readWord(func_calls[i].a1 + 0x8),
-                                    readWord(func_calls[i].a1 + 0xC)
-                                 );
-                                seg.SegStart = func_calls[i].a1;
-                                seg02_uncompressedOffset = readWordUnsigned(func_calls[i].a1 + 0xC);
-                            }
-                        }
+                    seg02_init = Globals.seg02_init_JP;
+                    RAMtoROM = Globals.RAMtoROM_JP;
                     break;
                 case ROM_Region.JAPAN_SHINDOU:
-                    func_calls = ar.findJALsInFunction(Globals.seg02_init_JS, Globals.RAMtoROM_JS);
-                    for (int i = 0; i < func_calls.Count; i++)
-                        if (func_calls[i].a0 == 0x2)
-                        {
-                            Globals.seg02_location = new[] { func_calls[i].a1, func_calls[i].a2 };
-                            if (readWordUnsigned(func_calls[i].a1) == 0x4D494F30)
-                            {
-                                seg.IsMIO0 = true;
-                                seg02_isFakeMIO0 = testIfMIO0IsFake(
-                                    func_calls[i].a1,
-                                    readWord(func_calls[i].a1 + 0x8),
-                                    readWord(func_calls[i].a1 + 0xC)
-                                 );
-                                seg.SegStart = func_calls[i].a1;
-                                seg02_uncompressedOffset = readWordUnsigned(func_calls[i].a1 + 0xC);
-                            }
-                        }
+                    seg02_init = Globals.seg02_init_JS;
+                    RAMtoROM = Globals.RAMtoROM_JS;
                     break;
             }
+
+            func_calls = ar.findJALsInFunction(seg02_init, RAMtoROM);
+            for (int i = 0; i < func_calls.Count; i++)
+            {
+                if (func_calls[i].a0 == 0x2)
+                {
+                    Globals.seg02_location = new[] { func_calls[i].a1, func_calls[i].a2 };
+                    if (readWordUnsigned(func_calls[i].a1) == 0x4D494F30)
+                    {
+                        seg.IsMIO0 = true;
+                        seg02_isFakeMIO0 = testIfMIO0IsFake(
+                            func_calls[i].a1,
+                            readWord(func_calls[i].a1 + 0x8),
+                            readWord(func_calls[i].a1 + 0xC)
+                         );
+                        seg.SegStart = func_calls[i].a1;
+                        seg02_uncompressedOffset = readWordUnsigned(func_calls[i].a1 + 0xC);
+                    }
+                }
+            }
+
             setSegment(0x2, seg, null);
         }
 

--- a/src/ROM.cs
+++ b/src/ROM.cs
@@ -693,6 +693,10 @@ namespace Quad64
                     seg02_init = Globals.seg02_init_JS;
                     RAMtoROM = Globals.RAMtoROM_JS;
                     break;
+                case ROM_Region.CHINESE_IQUE:
+                    seg02_init = Globals.seg02_init_IQ;
+                    RAMtoROM = Globals.RAMtoROM_IQ;
+                    break;
             }
 
             func_calls = ar.findJALsInFunction(seg02_init, RAMtoROM);


### PR DESCRIPTION
There was some duplicated code in the findAndSetSegment02(), so I de-duplicated it. I also fixed a bug where the app would use North American offsets to find segment02 in the Chinese ROM. It only ended up being off by 4 bytes and still managed to find segment 02 successfully, so ultimately there is no noticeable change to the end user.