### PR TITLE
Fix swapped descriptions for behavior commands 0x0F and 0x10

### DIFF
--- a/src/Scripts/BehaviorScripts.cs
+++ b/src/Scripts/BehaviorScripts.cs
@@ -91,10 +91,10 @@ namespace Quad64.src.Scripts
                         desc = "(Set value) obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2") + " = (float)" + bytesToInt(cmd, 2, 2);
                         break;
                     case 0x0F:
-                        desc = "(Set value) obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2") + " = " + (short)(bytesToInt(cmd, 2, 2) & 0xFFFF);
+                        desc = "Add " + (short)(bytesToInt(cmd, 2, 2) & 0xFFFF) + " to the value at obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2");
                         break;
                     case 0x10:
-                        desc = "Add " + (short)(bytesToInt(cmd, 2, 2) & 0xFFFF) + " to the value at obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2");
+                        desc = "(Set value) obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2") + " = " + (short)(bytesToInt(cmd, 2, 2) & 0xFFFF);
                         break;
                     case 0x11:
                         desc = "(Set bits) obj->_0x" + (cmd[1] * 4 + 0x88).ToString("X2")+ " |= 0x" + bytesToInt(cmd, 2, 2).ToString("X4");


### PR DESCRIPTION
There is a discrepancy between the descriptions given by Quad64's script dump feature for behavior commands 0x0F and 0x10, and hack64.net. This PR corrects this discrepancy.

I have disassembled the code for behavior commands 0x0F and 0x10, and verified that the hack64 descriptions are the correct ones.