### PR TITLE
Disable optimizations for debug build.

### DIFF
--- a/Quad64.csproj
+++ b/Quad64.csproj
@@ -33,7 +33,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>


### PR DESCRIPTION
This PR disabled optimizations for the debug build. Debug builds normally have optimizations turned off, as optimizations can cause some issues with debugging.

It also changes the platform target on the release build to Any CPU. As far as I can tell, Quad64 doesn't interface with any native binaries, so there isn't a good reason for restricting it to x86.