### PR TITLE
Fixed a crash when loading a script with a 0x1E command

### DIFF
--- a/src/Scripts/GeoScripts.cs
+++ b/src/Scripts/GeoScripts.cs
@@ -393,6 +393,7 @@ namespace Quad64.src.Scripts
                 case 0x19:
                 case 0x1A:
                 case 0x1D:
+                case 0x1E:
                     return 0x08;
                 case 0x08:
                 case 0x0A:


### PR DESCRIPTION
The 0x1E command is a 8-byte NOP command. While useless and unused in vanilla SM64, my soon-to-be-release ROMhacking tool changes the behaviour of this command to support each area having its own background. Since Quad64 doesn't have a length set for this command, it crashes.